### PR TITLE
Fix(snippet): Error that occurred when there were no linked resources in the document

### DIFF
--- a/core/components/collections/elements/snippets/getSelections.php
+++ b/core/components/collections/elements/snippets/getSelections.php
@@ -73,6 +73,8 @@ $linkedResourcesQuery->stmt->execute();
 
 $linkedResources = $linkedResourcesQuery->stmt->fetchAll(PDO::FETCH_COLUMN, 0);
 
+if (empty($linkedResources)) return '';
+
 if (!empty($excludeToPlaceholder)) {
     $excludeResources = [];
     foreach($linkedResources as $res) {

--- a/core/components/collections/elements/snippets/getSelections.php
+++ b/core/components/collections/elements/snippets/getSelections.php
@@ -73,8 +73,6 @@ $linkedResourcesQuery->stmt->execute();
 
 $linkedResources = $linkedResourcesQuery->stmt->fetchAll(PDO::FETCH_COLUMN, 0);
 
-if (empty($linkedResources)) return '';
-
 if (!empty($excludeToPlaceholder)) {
     $excludeResources = [];
     foreach($linkedResources as $res) {
@@ -89,12 +87,17 @@ $linkedResources = implode(',', $linkedResources);
 $properties = $scriptProperties;
 unset($properties['selections']);
 
-$properties['resources'] = $linkedResources;
 $properties['parents'] = ($properties['getResourcesSnippet'] == 'pdoResources') ? 0 : -1;
 
-if ($sortBy == '') {
-    $properties['sortby'] = 'FIELD(modResource.id, ' . $linkedResources . ' )';
-    $properties['sortdir'] = 'asc';
-}
+if (empty($linkedResources)) {
+    $properties['where'] = '2=1';
+} else {
+    $properties['resources'] = $linkedResources;
+    
+    if ($sortBy == '') {
+        $properties['sortby'] = 'FIELD(modResource.id, ' . $linkedResources . ' )';
+        $properties['sortdir'] = 'asc';
+    }
+};
 
 return $modx->runSnippet($getResourcesSnippet, $properties);


### PR DESCRIPTION
When there are no linked resources in the document and the snippet getSelections is called, an error occurs due to an incorrectly composed query "sortby FIELD(...) in getSelections snippet (on line 94).

![Screenshot from 2024-10-02 10-52-09](https://github.com/user-attachments/assets/2fb60c7b-5472-4c9a-8eaa-1d14cc276292)
Error: Error 42000: You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near ') asc LIMIT 10' at line 1

Also, as far as I understand, it makes no sense to call the snippet getResources (pdoResources) if we already know that there are no linked resources. I suggest returning an empty result immediately if there are no linked resources in the document.